### PR TITLE
Fix the downloading issues of pre-trained models

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Relevant codes were documented in "codes/example_attention_compute.ipynb". Brief
 * Default file path
   * The codes will assume the input data to be placed in "data/info_attention.txt".
   * The codes will load the pretrained CREformer model from "pretrained_models/".
-  * The downloading process requires installation of git-lfs. The instruction is: ```git-lfs clone https://huggingface.co/GenomicIntelligenceDamoAcademy/CREformer```.
+  * The downloading process requires installation of git-lfs. The instruction is: "git-lfs clone https://huggingface.co/GenomicIntelligenceDamoAcademy/CREformer".
 
 After you have prepared the input data, run the codes cell by cell in the .ipynb file. The codes will print out the output information, which includes the Attention Score for each ATAC peak.
   * Output data format:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Relevant codes were documented in "codes/example_attention_compute.ipynb". Brief
 * Default file path
   * The codes will assume the input data to be placed in "data/info_attention.txt".
   * The codes will load the pretrained CREformer model from "pretrained_models/".
+  * The downloading process requires installation of git-lfs. The instruction is: ```git-lfs clone https://huggingface.co/GenomicIntelligenceDamoAcademy/CREformer```.
 
 After you have prepared the input data, run the codes cell by cell in the .ipynb file. The codes will print out the output information, which includes the Attention Score for each ATAC peak.
   * Output data format:


### PR DESCRIPTION
Hi, I found that the instructions of Huggingface for cloning the folders are wrong because the folder contains large files, which cannot be directly downloaed by the git clone code provided by Huggingface. Therefore, I add an instruction to correctly download the large pre-trained models.

<img width="664" alt="image" src="https://github.com/user-attachments/assets/fe27c504-4763-4584-9c3c-e442d4da044f" />
